### PR TITLE
Replace django-jsonfield library for Django 4.2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 .tox/
 *.egg-info/
+venv/
+venv

--- a/dbag/__init__.py
+++ b/dbag/__init__.py
@@ -3,7 +3,7 @@ Dbag- Easy time-series metrics and dashboarding
 """
 import copy
 
-__version__ = '0.1.3'
+__version__ = '0.2.0'
 __author__ = 'Wes Winham'
 __contact__ = 'winhamwr@gmail.com'
 __homepage__ = 'http://github.com/winhamwr/dbag'
@@ -31,4 +31,3 @@ def autodiscover():
             # this import will have to reoccur on the next request and this
             # could raise NotRegistered and AlreadyRegistered exceptions
             dbag_manager._registry = before_import_registry
-

--- a/dbag/models.py
+++ b/dbag/models.py
@@ -3,8 +3,6 @@ import datetime
 from django.db import models
 from django.urls import reverse
 
-from jsonfield import JSONField
-
 class MetricCollectionDisabled(Exception):
     """
     Thrown when we attempt to collect a new ``DataSample`` for a ``Metric`` that
@@ -58,7 +56,7 @@ class Metric(models.Model):
 
     """
     metric_type_label = models.CharField(max_length=200)
-    metric_properties = JSONField(default="{}")
+    metric_properties = models.JSONField(default=dict)
 
     slug = models.CharField(max_length=75, unique=True)
     label = models.CharField(max_length=75)

--- a/dbag/tests/tests.py
+++ b/dbag/tests/tests.py
@@ -188,3 +188,32 @@ class ClientTests(TestCase):
         self.assertContains(response, 'Number of User Accounts')
         self.assertNotContains(response, 'class="no-data-collected"')
         self.assertNotContains(response, settings.TEMPLATE_STRING_IF_INVALID)
+
+
+class JSONFieldTest(TestCase):
+    """
+    Test the update from django-jsonfield to Django's models.JSONField
+    """
+    def test_json_field(self):
+        # Test storing and retrieving JSON
+        metric = Metric.objects.create(
+            metric_type_label="type_label",
+            metric_properties={"key": "metric_value"},
+            slug="slug",
+            label="label",
+            unit_label="unit_label",
+            unit_label_plural="unit_labels"
+        )
+
+        saved_metric = Metric.objects.get(id=metric.id)
+        self.assertEqual(saved_metric.metric_properties["key"], "metric_value")
+
+        # Test the default value for metric_properties
+        empty_metric_properties = Metric.objects.create(
+            metric_type_label="type_label_2",
+            slug="slug_2",
+            label="label_2",
+            unit_label="unit_label_2",
+            unit_label_plural="unit_labels_2"
+        )
+        self.assertEqual(empty_metric_properties.metric_properties, {})

--- a/runtests.py
+++ b/runtests.py
@@ -24,6 +24,7 @@ if not settings.configured:
         ],
         ROOT_URLCONF='dbag.urls',
         DEBUG=False,
+        SECRET_KEY='dummy-key-for-testing',
         TEMPLATE_STRING_IF_INVALID="INVALID_TEMPLATE_VARIABLE",
         TEMPLATES=[{
             'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ setup(
     platforms=['any'],
     classifiers=CLASSIFIERS,
     install_requires=[
-        'django-jsonfield',
-        'Django>=1.1',
+        'Django>=3.1',
     ],
     test_suite='runtests.runtests',
     include_package_data=True,


### PR DESCRIPTION
The `django-jsonfield` library is deprecated and not maintained. Replace the use of `django-jsonfield` with `models.JSONField()`. 

[Reference](https://docs.djangoproject.com/en/4.2/releases/3.1/#jsonfield-for-all-supported-database-backends)
